### PR TITLE
修复 genics 函数的作用域问题

### DIFF
--- a/course2ics.js
+++ b/course2ics.js
@@ -1,4 +1,4 @@
-function genics(firstMonday) {
+let genics = function(firstMonday) {
   // Author: @Saafo
   // Version: v0.2.0
   // Link: https://github.com/Saafo/uestc-coursetable-parser/blob/master/course2ics.js
@@ -207,4 +207,4 @@ END:VTIMEZONE\n\
   element.click();
   document.body.removeChild(element);
 };
-genics('20210301');
+genics('20240226');


### PR DESCRIPTION
问题描述:
在 macOS 14.2.1 (23C71) 系统上，使用 Microsoft Edge 浏览器 (版本 120.0.2210.91, 官方arm64构建版本) 运行脚本时，使用 `var` 声明 `genics` 函数会导致 `EvalError`。错误信息提示 `Identifier 'genics' cannot be declared with 'var' in current evaluation scope, consider trying 'let' instead`。

解决方案:
将 `genics` 函数的声明从 `var` 改为 `let`。这样做的原因是 `let` 提供了块级作用域，而 `var` 提供的是函数级作用域。在某些执行环境下，尤其是在特定版本的浏览器和操作系统组合中，使用 `var` 可能会导致作用域冲突，而 `let` 则能更好地限制变量的作用域，防止此类错误。

修改后的代码:

```javascript
let genics = function(firstMonday) {
  // 函数体保持不变
};

genics('20240225');